### PR TITLE
Add conda build recipe

### DIFF
--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -1,10 +1,10 @@
-name: Test Python package
+name: Test Conda Package
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
   workflow_dispatch:
     inputs:
       logLevel:
@@ -23,14 +23,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        python-version: ${{ matrix.python-version }}
+          environment-file: false
+          environment-name: env-py${{ matrix.python-version}}
+          channels: default,conda-forge,marvinquiet
+          extra-specs: |
+            python=${{ matrix.python-version }}
+            cellcano-base
     - name: Run Unittests
       run: |
         python -m unittest

--- a/.github/workflows/test_python_package.yml
+++ b/.github/workflows/test_python_package.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8"]
 
     steps:
     - uses: actions/checkout@v3
@@ -37,5 +37,6 @@ jobs:
             python=${{ matrix.python-version }}
             cellcano-base
     - name: Run Unittests
+      shell: bash -l {0}
       run: |
         python -m unittest

--- a/build_conda.sh
+++ b/build_conda.sh
@@ -1,0 +1,28 @@
+if [ -d "./conda-bld" ]
+then
+    echo "Directory ./conda-bld exists. Clear it."
+    rm -rf ./conda-bld/*
+else
+    echo "Directory ./conda-bld NOT exists. 'mkdir' for it!"
+    mkdir ./conda-bld
+fi
+
+if [ -x "$(command -v mamba)" ]
+then
+    echo "'mamba' installed. So we will use The Fast Mamba."
+    mybuild="mambabuild"
+else
+    echo "'mamba' NOT installed. We just use 'conda build'"
+    mybuild="build"
+fi
+
+# execute build recipe
+conda ${mybuild} conda-recipe --output-folder ./conda-bld
+
+# convert for all platforms; this can also be done through anaconda upload
+# cd conda-bld
+# conda convert -p all osx-64/cellcano*.tar.bz2
+# cd ..
+
+# after `anaconda login`
+# anaconda upload ./conda-bld/osx-64/cellcano*-0.0.2*.tar.bz2 --all

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+python:
+  - 3.8
+bld_opt:
+  - all
+  - base

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.0.2" %}
+
+package:
+  name: cellcano-{{ bld_opt }}
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python {{ python }}
+    - pip
+  run:
+    - python
+    - conda-forge::r-base ==4.1.1    # [bld_opt=='all']
+    - conda-forge::r-rlang >=1.0.0   # [bld_opt=='all']
+    - conda-forge::r-devtools        # [bld_opt=='all']
+    - conda-forge::r-biocmanager     # [bld_opt=='all']
+    - conda-forge::rpy2              # [bld_opt=='all']
+    - tensorflow ==2.4.1             
+    - six ~=1.15.0
+    - conda-forge::anndata ==0.7.4
+    - scanpy ==1.8.2
+    - numpy ==1.19.2
+    - h5py ==2.10.0
+    - keras
+  
+test:
+  imports:
+    - Cellcano
+
+about:
+  home: https://marvinquiet.github.io/Cellcano/
+  license: MIT
+  summary: Supervised cell type identification in single-cell genomics data
+
+extra:
+  maintainers:
+    - Wenjing Ma (wenjing.ma@emory.edu)
+    - Jiaying Lu (jiaying.lu@emory.edu)


### PR DESCRIPTION
For @marvinquiet 
- [ ] using `conda install -c marvinquiet cellcano-all`, we still need to manually go through ArchR installation in R console. Because ArchR does not support conda. I do pre-install `r-devtools` and `r-biocmanager` as two prerequisites for ArchR
- [ ] `build_conda.sh` stores scripts needed to build and publish conda package.
- [ ] Other todos in #3 